### PR TITLE
Fixed Rotary4Bit switches to not release wrong buttons

### DIFF
--- a/DahlDesignDDC/44_EEPROMFunctions.ino
+++ b/DahlDesignDDC/44_EEPROMFunctions.ino
@@ -1,23 +1,23 @@
 void write16bitToEEPROM(uint16_t location, uint16_t value)
 {
 #if ((USING_CAT24C512 == 1 && CAT24C512_I2C_NUMBER == 0) || USING_CB1 == 1 || USING_32U4EEPROM == 1)
-  
+
   #if (USING_32U4EEPROM)
     uint8_t firstByte = value >> 8;
     uint8_t lastByte = value & 0xff;
-    EEPROM.write(location,firstByte);
+    EEPROM.update(location,firstByte);
     delay(5);
-    EEPROM.write(location+1,lastByte);
-    delay(5);   
+    EEPROM.update(location+1,lastByte);
+    delay(5);
   #else
     uint8_t reg1 = location >> 8;
     uint8_t reg2 = location & 0xff;
 
     Wire.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-    
+
     Wire.write(reg1);
-    Wire.write(reg2); 
+    Wire.write(reg2);
 
     uint8_t firstByte = value >> 8;
     uint8_t lastByte = value & 0xff;
@@ -25,33 +25,33 @@ void write16bitToEEPROM(uint16_t location, uint16_t value)
     Wire.write(lastByte);
     Wire.endTransmission();
     delayMicroseconds(200);
-  #endif  
+  #endif
 #elif (USING_CAT24C512 == 1 && CAT24C512_I2C_NUMBER == 1)
-  
+
     uint8_t reg1 = location >> 8;
     uint8_t reg2 = location & 0xff;
 
     Wire1.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-    
+
     Wire1.write(reg1);
-    Wire1.write(reg2); 
+    Wire1.write(reg2);
 
     uint8_t firstByte = value >> 8;
     uint8_t lastByte = value & 0xff;
     Wire1.write(firstByte);
     Wire1.write(lastByte);
     Wire1.endTransmission();
-    delayMicroseconds(200); 
+    delayMicroseconds(200);
 #else
-  EEPROMdump = location + value;  
+  EEPROMdump = location + value;
 #endif
  }
 
 uint16_t read16bitFromEEPROM(uint16_t location)
 {
 #if ((USING_CAT24C512 == 1 && CAT24C512_I2C_NUMBER == 0) || USING_CB1 == 1 || USING_32U4EEPROM == 1)
-  
+
   #if (USING_32U4EEPROM)
     uint16_t value = 0;
     value = EEPROM.read(location);
@@ -66,7 +66,7 @@ uint16_t read16bitFromEEPROM(uint16_t location)
 
     Wire.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-    
+
     Wire.write(reg1);
     Wire.write(reg2);
     Wire.endTransmission();
@@ -78,7 +78,7 @@ uint16_t read16bitFromEEPROM(uint16_t location)
     value = value << 8;
     value |= Wire.read();
     delayMicroseconds(200);
-    
+
     return value;
   #endif
 
@@ -89,7 +89,7 @@ uint16_t read16bitFromEEPROM(uint16_t location)
 
     Wire1.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-    
+
     Wire1.write(reg1);
     Wire1.write(reg2);
     Wire1.endTransmission();
@@ -101,13 +101,13 @@ uint16_t read16bitFromEEPROM(uint16_t location)
     value = value << 8;
     value |= Wire1.read();
     delayMicroseconds(200);
-    
+
     return value;
-    
+
 #else
 
   return location * 0;
-  
+
 #endif
 }
 
@@ -151,7 +151,7 @@ void EEPROMinit()
     MFR = read16bitFromEEPROM(MASTERRELEASED);
     SFP = read16bitFromEEPROM(SLAVEPRESSED);
     SFR = read16bitFromEEPROM(SLAVERELEASED);
-    
+
     oldBitePoint = bitePoint;
     oldLED = LEDBrightness;
     oldBrake = brakeMagicValue;
@@ -169,7 +169,7 @@ void EEPROMchanges()
       oldPreset = switchPreset;
       write16bitToEEPROM(PRESETSLOT,switchPreset);
     }
-  
+
     //BITE POINT
     if (pushState[biteButtonRow - 1][biteButtonCol - 1] == 0 && (biteButtonBit1 + biteButtonBit2 == 0) && oldBitePoint != bitePoint)
     {
@@ -193,7 +193,7 @@ void EEPROMchanges()
     {
       oldThrottle = throttleHoldValue;
       write16bitToEEPROM(THROTTLESLOT+(switchPreset * 2), throttleHoldValue);
-    }    
+    }
 
 #endif
 }

--- a/DahlDesignDDC/44_EEPROMFunctions.ino
+++ b/DahlDesignDDC/44_EEPROMFunctions.ino
@@ -1,23 +1,23 @@
 void write16bitToEEPROM(uint16_t location, uint16_t value)
 {
 #if ((USING_CAT24C512 == 1 && CAT24C512_I2C_NUMBER == 0) || USING_CB1 == 1 || USING_32U4EEPROM == 1)
-
+  
   #if (USING_32U4EEPROM)
     uint8_t firstByte = value >> 8;
     uint8_t lastByte = value & 0xff;
-    EEPROM.update(location,firstByte);
+    EEPROM.write(location,firstByte);
     delay(5);
-    EEPROM.update(location+1,lastByte);
-    delay(5);
+    EEPROM.write(location+1,lastByte);
+    delay(5);   
   #else
     uint8_t reg1 = location >> 8;
     uint8_t reg2 = location & 0xff;
 
     Wire.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-
+    
     Wire.write(reg1);
-    Wire.write(reg2);
+    Wire.write(reg2); 
 
     uint8_t firstByte = value >> 8;
     uint8_t lastByte = value & 0xff;
@@ -25,33 +25,33 @@ void write16bitToEEPROM(uint16_t location, uint16_t value)
     Wire.write(lastByte);
     Wire.endTransmission();
     delayMicroseconds(200);
-  #endif
+  #endif  
 #elif (USING_CAT24C512 == 1 && CAT24C512_I2C_NUMBER == 1)
-
+  
     uint8_t reg1 = location >> 8;
     uint8_t reg2 = location & 0xff;
 
     Wire1.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-
+    
     Wire1.write(reg1);
-    Wire1.write(reg2);
+    Wire1.write(reg2); 
 
     uint8_t firstByte = value >> 8;
     uint8_t lastByte = value & 0xff;
     Wire1.write(firstByte);
     Wire1.write(lastByte);
     Wire1.endTransmission();
-    delayMicroseconds(200);
+    delayMicroseconds(200); 
 #else
-  EEPROMdump = location + value;
+  EEPROMdump = location + value;  
 #endif
  }
 
 uint16_t read16bitFromEEPROM(uint16_t location)
 {
 #if ((USING_CAT24C512 == 1 && CAT24C512_I2C_NUMBER == 0) || USING_CB1 == 1 || USING_32U4EEPROM == 1)
-
+  
   #if (USING_32U4EEPROM)
     uint16_t value = 0;
     value = EEPROM.read(location);
@@ -66,7 +66,7 @@ uint16_t read16bitFromEEPROM(uint16_t location)
 
     Wire.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-
+    
     Wire.write(reg1);
     Wire.write(reg2);
     Wire.endTransmission();
@@ -78,7 +78,7 @@ uint16_t read16bitFromEEPROM(uint16_t location)
     value = value << 8;
     value |= Wire.read();
     delayMicroseconds(200);
-
+    
     return value;
   #endif
 
@@ -89,7 +89,7 @@ uint16_t read16bitFromEEPROM(uint16_t location)
 
     Wire1.beginTransmission(CAT24C512_ADDRESS);
     delayMicroseconds(200);
-
+    
     Wire1.write(reg1);
     Wire1.write(reg2);
     Wire1.endTransmission();
@@ -101,13 +101,13 @@ uint16_t read16bitFromEEPROM(uint16_t location)
     value = value << 8;
     value |= Wire1.read();
     delayMicroseconds(200);
-
+    
     return value;
-
+    
 #else
 
   return location * 0;
-
+  
 #endif
 }
 
@@ -151,7 +151,7 @@ void EEPROMinit()
     MFR = read16bitFromEEPROM(MASTERRELEASED);
     SFP = read16bitFromEEPROM(SLAVEPRESSED);
     SFR = read16bitFromEEPROM(SLAVERELEASED);
-
+    
     oldBitePoint = bitePoint;
     oldLED = LEDBrightness;
     oldBrake = brakeMagicValue;
@@ -169,7 +169,7 @@ void EEPROMchanges()
       oldPreset = switchPreset;
       write16bitToEEPROM(PRESETSLOT,switchPreset);
     }
-
+  
     //BITE POINT
     if (pushState[biteButtonRow - 1][biteButtonCol - 1] == 0 && (biteButtonBit1 + biteButtonBit2 == 0) && oldBitePoint != bitePoint)
     {
@@ -193,7 +193,7 @@ void EEPROMchanges()
     {
       oldThrottle = throttleHoldValue;
       write16bitToEEPROM(THROTTLESLOT+(switchPreset * 2), throttleHoldValue);
-    }
+    }    
 
 #endif
 }

--- a/DahlDesignDDC/60_Rotary4Bit.ino
+++ b/DahlDesignDDC/60_Rotary4Bit.ino
@@ -32,7 +32,7 @@ void rotary4Modes(int row, int column, int fieldPlacement, int hybridPositions, 
         }
     }
 
-    pos = pos ^ (pos >> 4);
+    //pos = pos ^ (pos >> 4);
     pos = pos ^ (pos >> 2);
     pos = pos ^ (pos >> 1);
 
@@ -231,7 +231,7 @@ void rotary4Inc(int row, int column, bool reverse)
         }
     }
 
-    pos = pos ^ (pos >> 4);
+    //pos = pos ^ (pos >> 4);
     pos = pos ^ (pos >> 2);
     pos = pos ^ (pos >> 1);
 
@@ -299,7 +299,7 @@ void rotary4Mod(int row, int column, bool reverse)
         }
     }
 
-    pos = pos ^ (pos >> 4);
+    //pos = pos ^ (pos >> 4);
     pos = pos ^ (pos >> 2);
     pos = pos ^ (pos >> 1);
 
@@ -371,10 +371,10 @@ void rotary4Stack (int stackButtonRow, int stackButtonColumn, int fieldPlacement
     {
       toggleTimer[ButtonRow][ButtonCol] = 0;
     }
-    
+
     //Adjust button number
 
-    int Number = buttonNumber[Row][Column] + toggleTimer[ButtonRow][ButtonCol] * 2;  
+    int Number = buttonNumber[Row][Column] + toggleTimer[ButtonRow][ButtonCol] * 2;
     //Find switch absolute position
 
     bool Pin1 = rawState[Row][Column];
@@ -394,7 +394,7 @@ void rotary4Stack (int stackButtonRow, int stackButtonColumn, int fieldPlacement
         }
     }
 
-    pos = pos ^ (pos >> 4);
+    //pos = pos ^ (pos >> 4);
     pos = pos ^ (pos >> 2);
     pos = pos ^ (pos >> 1);
 
@@ -429,7 +429,7 @@ void rotary4Stack (int stackButtonRow, int stackButtonColumn, int fieldPlacement
             pushState[Row][Column] = result;
         }
     }
-    
+
     //Push stack placement
     long push = 0;
     push = push | toggleTimer[ButtonRow][ButtonCol];
@@ -464,7 +464,7 @@ void rotary4Multi(int row, int column, int positions, bool reverse)
         }
     }
 
-    pos = pos ^ (pos >> 4);
+    //pos = pos ^ (pos >> 4);
     pos = pos ^ (pos >> 2);
     pos = pos ^ (pos >> 1);
 
@@ -503,7 +503,7 @@ void rotary4Multi(int row, int column, int positions, bool reverse)
                 pushState[Row][Column + 2] = Pos - 1;
             }
 
-            for (int i = 0; i < Pos + 1; i++)
+            for (int i = 1; i <= Pos; i++)
             {
                 int e = pushState[Row][Column + 2] % Pos;
                 if (e == 0)
@@ -552,7 +552,7 @@ void rotary4Multis(int row, int column, int fieldPlacement, int positions1, int 
         }
     }
 
-    pos = pos ^ (pos >> 4);
+    //pos = pos ^ (pos >> 4);
     pos = pos ^ (pos >> 2);
     pos = pos ^ (pos >> 1);
 
@@ -578,7 +578,7 @@ void rotary4Multis(int row, int column, int fieldPlacement, int positions1, int 
 
             if (pushState[modButtonRow - 1][modButtonCol - 1] == 1 && FieldPlacement != 0)
             {
-                for (int i = 0; i < maxPos + 1; i++) //Remove the remnants from SWITCH MODE 1
+                for (int i = 1; i <= maxPos; i++) //Remove the remnants from SWITCH MODE 1
                 {
                     Joystick.releaseButton(i - 1 + Number);
                 }
@@ -663,7 +663,7 @@ void rotary4Multis(int row, int column, int fieldPlacement, int positions1, int 
         {
             //SWITCH MODE 2-4: Multiposititon switches
 
-            for (int i = 0; i < pushState[Row][Column + 3] + 1; i++) //Col pin 4 push state holds info on how many positions on multiposition switch
+            for (int i = 1; i <= pushState[Row][Column + 3]; i++) //Col pin 4 push state holds info on how many positions on multiposition switch
             {
                 int e = pushState[Row][Column + 2] % pushState[Row][Column + 3];
                 if (e == 0)
@@ -705,8 +705,8 @@ void DDS4bit(int row, int column, bool reverse)
         toggleTimer[Row][Column] = read16bitFromEEPROM(DDS_s);
       }
     #endif
-    
-    if (latchState[ddButtonRow - 1][ddButtonCol - 1] && !switchMode[Row][Column + 1])  //Jumping 
+
+    if (latchState[ddButtonRow - 1][ddButtonCol - 1] && !switchMode[Row][Column + 1])  //Jumping
     {
         Number = Number + 12;
         if (!switchMode[Row][Column])
@@ -717,7 +717,7 @@ void DDS4bit(int row, int column, bool reverse)
             }
         }
     }
-    
+
     //Find switch absolute position
 
     bool Pin1 = rawState[Row][Column];
@@ -737,7 +737,7 @@ void DDS4bit(int row, int column, bool reverse)
         }
     }
 
-    pos = pos ^ (pos >> 4);
+    //pos = pos ^ (pos >> 4);
     pos = pos ^ (pos >> 2);
     pos = pos ^ (pos >> 1);
 
@@ -1000,7 +1000,7 @@ void DDS4bit(int row, int column, bool reverse)
         //Clearing all buttons on mode change
         if (latchLock[ddButtonRow - 1][ddButtonCol - 1] && !(switchMode[Row][Column] && !switchMode[Row][Column + 1]))
         {
-            for (int i = 0; i < 13; i++) //Remove the remnants from SWITCH MODE 1
+            for (int i = 1; i <= 13; i++) //Remove the remnants from SWITCH MODE 1
             {
                 Joystick.releaseButton(i - 1 + buttonNumber[Row][Column]);
             }


### PR DESCRIPTION
I commented all the xor's with 4 shift right's because with 4 pins it would always be 0 and so the result always the same, or am i missing something?

Since the processors are quite weak, having for with "< VAR + 1" takes more time than "<= VAR", this should be applied to all for's within the project whenever it is possible as an optimization

The main reason of this fork is to fix a bug with the for to release buttons when changing the switch, with i starting at 0 it will release the previous button because it has the code `Joystick.releaseButton(i - 1 + Number);` and it will release the `Number - 1`

PS.: My editor changed some of the extra spaces